### PR TITLE
Feature/default datetime attribute update

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,15 +133,17 @@ $this->authorizationService->limitGetCollection($resourceClass, $queryBuilder); 
 ```
 - In DataProvider, getItem:
 ```php
-$this->authorizationService->authorizeSingleEntity($entity,'owner', $context); // This will throw AccessDeniedException if not authorized
+$this->authorizationService->authorizeSingleEntity($entity,'owner', AuthorizationService::ITEM_GET); // This will throw AccessDeniedException if not authorized
 ```
 - In DataPersister, persist:
 ```php
-$this->authorizationService->authorizeSingleResource($data, 'responsible', $context); // This will throw AccessDeniedException if not authorized
+$this->authorizationService->authorizeSingleResource($data, 'responsible', AuthorizationService::ITEM_WRITE); // This will throw AccessDeniedException if not authorized
+// or
+$this->authorizationService->authorizeSingleResource($data, 'responsible', AuthorizationService::COL_POST; // This will throw AccessDeniedException if not authorized
 ```
 - In DataPersister, remove:
 ```php
-$this->authorizationService->authorizeSingleResource($data, 'responsible', $context); // This will throw AccessDeniedException if not authorized
+$this->authorizationService->authorizeSingleResource($data, 'responsible', AuthorizationService::ITEM_WRITE); // This will throw AccessDeniedException if not authorized
 ```
 - In Any Resource, you want to limit output for non-OWN properties, add attribute to the resource class:
 ```php

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Bundle to map Doctrine entity object to and from API resource object.",
   "type": "symfony-bundle",
   "license": "MIT",
-  "version": "0.16.6",
+  "version": "0.17.0",
   "authors": [
     {
       "name": "Raitis Rasmanis",

--- a/src/Entity/BaseEntity.php
+++ b/src/Entity/BaseEntity.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace WhiteDigital\EntityResourceMapper\Entity;
 
-
+use DateTimeImmutable;
+use DateTimeZone;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\MappedSuperclass;
 use Symfony\Component\Serializer\Exception\ExceptionInterface;
@@ -15,36 +16,34 @@ use WhiteDigital\EntityResourceMapper\Resource\BaseResource;
 #[MappedSuperclass]
 abstract class BaseEntity
 {
-    #[ORM\Column(type: 'datetime')]
-    protected ?\DateTimeInterface $created = null;
+    #[ORM\Column(type: 'datetime_immutable')]
+    protected ?DateTimeImmutable $createdAt = null;
 
-    #[ORM\Column(type: 'datetime', nullable: true)]
-    protected ?\DateTimeInterface $updated = null;
+    #[ORM\Column(type: 'datetime_immutable', nullable: true)]
+    protected ?DateTimeImmutable $updatedAt = null;
 
-
-    public function getCreated(): ?\DateTimeInterface
+    public function getCreatedAt(): ?DateTimeImmutable
     {
-        return $this->created;
+        return $this->createdAt;
     }
 
-    public function getUpdated(): ?\DateTimeInterface
+    public function getUpdatedAt(): ?DateTimeImmutable
     {
-        return $this->updated;
+        return $this->updatedAt;
     }
-
 
     #[ORM\PrePersist]
     public function onPrePersist(): void
     {
-        $now = new \DateTime('now');
-        $this->created = $now;
-        $this->updated = $now;
+        $now = new DateTimeImmutable(timezone: new DateTimeZone('UTC'));
+        $this->createdAt = $now;
+        $this->updatedAt = $now;
     }
 
     #[ORM\PreUpdate]
     public function onPreUpdate(): void
     {
-        $this->updated = new \DateTime('now');
+        $this->updatedAt = new DateTimeImmutable(timezone: new DateTimeZone('UTC'));
     }
 
     abstract public function getId(): ?int;

--- a/src/Mapper/ResourceToEntityMapper.php
+++ b/src/Mapper/ResourceToEntityMapper.php
@@ -23,8 +23,8 @@ class ResourceToEntityMapper
     )
     {
         BaseEntity::setResourceToEntityMapper($this);
-        // We are using PHP configured timezone (Europe/Riga)
-        $this->timeZone = new \DateTimeZone(date_default_timezone_get());
+        // We should use UTC timezone for all datetimes.
+        $this->timeZone = new \DateTimeZone('UTC');
     }
 
     /**
@@ -56,9 +56,8 @@ class ResourceToEntityMapper
             }
 
             //  0. Set correct Timezone, as database does not store TZ info
-            if ($propertyType === \DateTimeInterface::class
-                && null !== $propertyValue) {
-                /** @var \DateTimeImmutable $propertyValue */
+            if (is_subclass_of($propertyValue, \DateTimeInterface::class)
+                && $propertyValue instanceof \DateTimeInterface) {
                 $propertyValue = $propertyValue->setTimezone($this->timeZone);
             }
 

--- a/src/Resource/BaseResource.php
+++ b/src/Resource/BaseResource.php
@@ -13,7 +13,7 @@ use WhiteDigital\EntityResourceMapper\Mapper\EntityToResourceMapper;
 
 abstract class BaseResource
 {
-    public ?int $id = null;
+    public mixed $id = null;
 
     public bool $isRestricted = false; // must set this property in resource class with correct Normalization group, if GrantType::OWN used on the resource
 


### PR DESCRIPTION
Closes #4

1. BaseEntity attributes created and updated refactored to createdAt and updatedAt
2. New attributes are of type DateTimeImmutable as the preferred choice.
3. New attributes are always with UTC datetimezone, even if set explicitly
4. ResourceToEntity mapper converts any resource property with DateTimeInterface as DateTImeImmutable with UTC timezone in entity