### PR TITLE
Change BaseEntity getId return type

### DIFF
--- a/src/Entity/BaseEntity.php
+++ b/src/Entity/BaseEntity.php
@@ -60,7 +60,7 @@ abstract class BaseEntity
         $this->updatedAt = new DateTimeImmutable(timezone: new DateTimeZone('UTC'));
     }
 
-    abstract public function getId(): ?int;
+    abstract public function getId(): mixed;
 
     private static ResourceToEntityMapper $resourceToEntityMapper;
 

--- a/src/Mapper/ResourceToEntityMapper.php
+++ b/src/Mapper/ResourceToEntityMapper.php
@@ -219,8 +219,8 @@ class ResourceToEntityMapper
             $equal = true;
             for ($i = 0, $iMax = count($firstSet); $i < $iMax; $i++) {
                 $classesAreEqual = get_class($firstSet[$i]) === $this->classMapper->byResource(get_class($secondSet[$i]), get_class($firstSet[$i]));
-                $idsAreEqual = $firstSet[$i]->getId() === $secondSet[$i]->id;
-                $equal = $equal && $classesAreEqual && $idsAreEqual;
+                $idsAreEqual = $firstSet[$i]->getId() === $secondSet[$i]->getId();
+                $equal = $classesAreEqual && $idsAreEqual;
                 if (!$equal) {
                     break;
                 }

--- a/src/Mapper/ResourceToEntityMapper.php
+++ b/src/Mapper/ResourceToEntityMapper.php
@@ -214,12 +214,12 @@ class ResourceToEntityMapper
         if ($value1 instanceof PersistentCollection && is_array($value2) && count($value1) === count($value2)) {
             /** @var BaseEntity[] $firstSet */
             $firstSet = $value1->getValues();
-            /** @var BaseEntity[] $secondSet */
+            /** @var BaseResource[] $secondSet */
             $secondSet = $value2;
             $equal = true;
             for ($i = 0, $iMax = count($firstSet); $i < $iMax; $i++) {
                 $classesAreEqual = get_class($firstSet[$i]) === $this->classMapper->byResource(get_class($secondSet[$i]), get_class($firstSet[$i]));
-                $idsAreEqual = $firstSet[$i]->getId() === $secondSet[$i]->getId();
+                $idsAreEqual = $firstSet[$i]->getId() === $secondSet[$i]->id;
                 $equal = $classesAreEqual && $idsAreEqual;
                 if (!$equal) {
                     break;

--- a/tests/Fixtures/ResourceClass.php
+++ b/tests/Fixtures/ResourceClass.php
@@ -12,7 +12,7 @@ use WhiteDigital\EntityResourceMapper\Resource\BaseResource;
 #[ApiFilter(ResourceSearchFilter::class, properties: ['number'])]
 class ResourceClass extends BaseResource
 {
-    public ?int $id = null;
+    public mixed $id = null;
     public int $number;
     public string $text;
     public ?\DateTimeImmutable $created = null;

--- a/tests/Fixtures/ResourceClass2.php
+++ b/tests/Fixtures/ResourceClass2.php
@@ -6,7 +6,7 @@ use WhiteDigital\EntityResourceMapper\Resource\BaseResource;
 
 class ResourceClass2 extends BaseResource
 {
-    public ?int $id = null;
+    public mixed $id = null;
     public string $text;
 
     public ?ResourceClass $parent;


### PR DESCRIPTION
Change BaseEntity getId return type to mixed to support various scalar types as entity identifiers

Closes #5 

1. Changed return type on BaseEntity getId()
2. small fixes regarding mapper and ids

