### PR TITLE
Fix Existing resource to entity mapping,

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Bundle to map Doctrine entity object to and from API resource object.",
   "type": "symfony-bundle",
   "license": "MIT",
-  "version": "0.16.6",
+  "version": "0.16.7",
   "authors": [
     {
       "name": "Raitis Rasmanis",

--- a/src/Mapper/ResourceToEntityMapper.php
+++ b/src/Mapper/ResourceToEntityMapper.php
@@ -44,8 +44,8 @@ class ResourceToEntityMapper
 
         foreach ($properties as $property) {
             $propertyName = $property->getName();
-            if (!property_exists($output, $propertyName)) {
-                continue; // Silently skip properties which do no exist on target class.
+            if (!property_exists($targetEntityClass, $propertyName)) {
+                continue; // Silently skip properties which do not exist on target class.
             }
             /** @phpstan-ignore-next-line */
             $propertyType = $property->getType()?->getName();


### PR DESCRIPTION
Existing resource (entity) can be a proxy, because used elsewhere.