### PR TITLE
Fix searching for singular method in entity

### DIFF
--- a/src/Mapper/ResourceToEntityMapper.php
+++ b/src/Mapper/ResourceToEntityMapper.php
@@ -165,21 +165,16 @@ class ResourceToEntityMapper
     private function callMethod(BaseEntity $object, string $method, string $property, mixed $value = null): mixed
     {
         $property = ucfirst($property);
-        $propertySingular = '';
         foreach ((new EnglishInflector())->singularize($property) as $singularValue) {
-            if (strlen($singularValue) > strlen($propertySingular)) {
-                $propertySingular = $singularValue;
+            try {
+                return $object->{"$method$singularValue"}($value);
+            } catch (Error $e) { // Catch only one type of errors
+                if (!str_contains($e->getMessage(), 'Call to undefined method')) {
+                    throw $e;
+                }
             }
         }
-        try {
-            return $object->{"$method$propertySingular"}($value);
-        } catch (Error $e) { // Catch only one type of errors
-            if (!str_contains($e->getMessage(), 'Call to undefined method')) {
-                throw $e;
-            }
-
-            return $object->{"$method$property"}($value);
-        }
+        return $object->{"$method$property"}($value);
     }
 
     private function compareValues(mixed $value1, mixed $value2): bool


### PR DESCRIPTION
Currently it is possible to encounter error while searching for singularized property method (for toMany associations, addX, removeX)
Currently the method is checked by longest one. THis is not sufficient enough.
This pull requests checks for each method name of singular result, and if it exists returns it, otherwise unmodified property method is returned.
 