### PR TITLE
"all" grant type already covers all operations

### DIFF
--- a/src/Security/AuthorizationService.php
+++ b/src/Security/AuthorizationService.php
@@ -231,7 +231,7 @@ final class AuthorizationService
         }
         $availableRoles = $forceRoles ?: $user->getRoles();
 
-        $allowedRoles = array_merge($this->resources[$resourceClass][$operation],
+        $allowedRoles = array_merge($this->resources[$resourceClass][$operation] ?? [],
             $this->resources[$resourceClass][self::ALL]);
 
         //IF OPERATION DOESN'T EXIST OR ROLE DOESN'T EXIST IN RESOURCE return NONE


### PR DESCRIPTION
GrantType::ALL jau aptver visus grantus, neredzu pamatojumu, kāpēc pārdefinēt citus grantus tukšus.

Šobrīd:
```php
AuthorizationService::ALL => [
    RoleTypeEnum::ROLE_SUPER_ADMIN => GrantType::ALL,
    RoleTypeEnum::ROLE_PROJECT_MANAGER => GrantType::ALL,
],
AuthorizationService::COL_GET => [],
AuthorizationService::ITEM_GET => [],
AuthorizationService::COL_POST => [],
AuthorizationService::ITEM_PATCH => [],
AuthorizationService::ITEM_DELETE => [],
```
Pēc izmaiņām:
```php
AuthorizationService::ALL => [
    RoleTypeEnum::ROLE_SUPER_ADMIN => GrantType::ALL,
    RoleTypeEnum::ROLE_PROJECT_MANAGER => GrantType::ALL,
],
```