### PR TITLE
fix: fix unnecessary reads if no groups key set

### DIFF
--- a/src/Mapper/EntityToResourceMapper.php
+++ b/src/Mapper/EntityToResourceMapper.php
@@ -367,6 +367,8 @@ class EntityToResourceMapper
     private function unsetNormalizationGroups(array $context, array $targetNormalizationGroups): array
     {
         if (!array_key_exists('groups', $context)) {
+            $context['groups'] = [];
+
             return $context;
         }
         $targetGroups = [];


### PR DESCRIPTION
Ja `groups` atslēgas vispār nav iekš `context`, tad pilnīgi visas pārbaudes pārbaudes par kopīgajām grupām utt. tiek pilnībā ignorētas un rada ļoti daudz datubāzes izsaukumu, piemēram, uz `PATCH` pieprasījuma